### PR TITLE
Revamp publications, homepage, and theme

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,37 +1,165 @@
 ---
 ---
 
+@inproceedings{jie2022learning,
+  abbr={ACL},
+  title={Learning to Reason Deductively: Math Word Problem Solving as Complex Relation Extraction},
+  author={Jie, Zhanming and Li, Jierui and Lu, Wei},
+  booktitle={Proceedings of ACL},
+  year={2022},
+  pdf={https://arxiv.org/pdf/2203.10316v1.pdf},
+  code={https://github.com/allanj/Deductive-MWP},
+  bibtex_show={true},
+  selected={true}
+}
+
+@inproceedings{zhou2021closer,
+  abbr={EMNLP},
+  title={To be Closer: Learning to Link up Aspect with Opinions},
+  author={Zhou, Yuxiang and Liao, Lejian and Gao, Yang and Jie, Zhanming and Lu, Wei},
+  booktitle={Proceedings of EMNLP},
+  year={2021},
+  pdf={https://aclanthology.org/2021.emnlp-main.317.pdf},
+  code={https://github.com/zyxnlp/aclt},
+  bibtex_show={true}
+}
+
+@inproceedings{xu2021better,
+  abbr={NAACL},
+  title={Better Feature Integration for Named Entity Recognition},
+  author={Xu, Lu and Jie, Zhanming and Lu, Wei and Bing, Lidong},
+  booktitle={Proceedings of NAACL},
+  year={2021},
+  pdf={https://www.aclweb.org/anthology/2021.naacl-main.271.pdf},
+  code={https://github.com/xuuuluuu/SynLSTM-for-NER},
+  bibtex_show={true},
+  selected={true}
+}
+
+@inproceedings{cheng2020entdesc,
+  abbr={EMNLP},
+  title={ENT-DESC: Entity Description Generation by Exploring Knowledge Graph},
+  author={Cheng, Liying and Wu, Dekun and Bing, Lidong and Zhang, Yan and Jie, Zhanming and Lu, Wei and Si, Luo},
+  booktitle={Proceedings of EMNLP},
+  year={2020},
+  html={https://www.aclweb.org/anthology/2020.emnlp-main.90/},
+  code={https://github.com/LiyingCheng95/EntityDescriptionGeneration},
+  slides={https://docs.google.com/presentation/d/1xuZ48Yl-wIHdrZME15Iimcw3eSQTF9_TiaIS7Mu6SoU/edit?usp=sharing},
+  bibtex_show={true}
+}
+
+@inproceedings{yang2020autoie,
+  abbr={NLPCC},
+  title={Overview of the NLPCC 2020 Shared Task: AutoIE},
+  author={Yang, Xuefeng and Wu, Benhong and Jie, Zhanming and Liu, Yunfeng},
+  booktitle={Proceedings of NLPCC},
+  year={2020},
+  html={https://link.springer.com/chapter/10.1007/978-3-030-60457-8_46},
+  bibtex_show={true}
+}
+
 @inproceedings{jie2019dependency,
+  abbr={EMNLP},
   title={Dependency-Guided LSTM-CRF for Named Entity Recognition},
   author={Jie, Zhanming and Lu, Wei},
-  booktitle={Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing and the 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP)},
+  booktitle={Proceedings of EMNLP},
   pages={3862--3872},
-  year={2019}
+  year={2019},
+  arxiv={1909.10148},
+  code={https://github.com/allanj/ner_with_dependency},
+  slides={https://docs.google.com/presentation/d/1tk0EcChsI-DIt0LvFVcubKvpCi3Ptg6OrnRx5U-CsO0/edit?usp=sharing},
+  bibtex_show={true},
+  selected={true}
 }
 
+@inproceedings{jie2019better,
+  abbr={NAACL},
+  title={Better Modeling of Incomplete Annotations for Named Entity Recognition},
+  author={Jie, Zhanming and Xie, Pengjun and Lu, Wei and Ding, Ruixue and Li, Linlin},
+  booktitle={Proceedings of NAACL},
+  year={2019},
+  html={https://www.aclweb.org/anthology/N19-1079},
+  code={https://github.com/allanj/ner_incomplete_annotation/},
+  slides={http://people.sutd.edu.sg/%7Eallanjie/wp-content/uploads/2019/07/presentation.pdf},
+  bibtex_show={true}
+}
+
+@inproceedings{jie2018dependency,
+  abbr={EMNLP},
+  title={Dependency-based Hybrid Trees for Semantic Parsing},
+  author={Jie, Zhanming and Lu, Wei},
+  booktitle={Proceedings of EMNLP},
+  year={2018},
+  arxiv={1809.00107},
+  code={https://github.com/allanj/dep-hybrid-tree},
+  slides={http://people.sutd.edu.sg/%7Eallanjie/wp-content/uploads/2016/04/dht_seminar_conf.pdf},
+  bibtex_show={true}
+}
+
+@inproceedings{jie2017efficient,
+  abbr={AAAI},
+  title={Efficient Dependency-Guided Named Entity Recognition},
+  author={Jie, Zhanming and Muis, Aldrian Obaja and Lu, Wei},
+  booktitle={Proceedings of AAAI},
+  year={2017},
+  pdf={http://people.sutd.edu.sg/%7Eallanjie/wp-content/uploads/2017/02/jie.pdf},
+  code={https://gitlab.com/allanjie/dependeny-guided-ner},
+  slides={http://www.statnlp.org/wp-content/uploads/2017/02/slides.pdf},
+  bibtex_show={true},
+  selected={true}
+}
 
 @inproceedings{jie2015cloud,
-  title={A cloud-assisted framework for bag-of-features tagging in social networks},
+  abbr={NCCA},
+  title={A Cloud-Assisted Framework for Bag-of-Features Tagging in Social Networks},
   author={Jie, Zhanming and Cheung, Ming and She, James},
-  booktitle={2015 IEEE Fourth Symposium on Network Cloud Computing and Applications (NCCA)},
+  booktitle={Proceedings of IEEE Fourth Symposium on Network Cloud Computing and Applications (NCCA)},
   pages={103--106},
   year={2015},
-  organization={IEEE}
-}
-
-@inproceedings{jie2014multilingual,
-  title={Multilingual semantic parsing: Parsing multiple languages into semantic representations},
-  author={Jie, Zhanming and Lu, Wei},
-  booktitle={Proceedings of COLING 2014, the 25th International Conference on Computational Linguistics: Technical Papers},
-  pages={1291--1301},
-  year={2014}
+  organization={IEEE},
+  html={http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=7340054},
+  bibtex_show={true}
 }
 
 @inproceedings{junus2015community,
-  title={Community-aware prediction of virality timing using big data of social cascades},
-  author={Junus, Alvin and Ming, Cheung and She, James and Jie, Zhanming},
-  booktitle={2015 IEEE First International Conference on Big Data Computing Service and Applications},
+  abbr={BigDataService},
+  title={Community-Aware Prediction of Virality Timing Using Big Data of Social Cascades},
+  author={Junus, Alvin and Cheung, Ming and She, James and Jie, Zhanming},
+  booktitle={Proceedings of IEEE First International Conference on Big Data Computing Service and Applications},
   pages={487--492},
   year={2015},
-  organization={IEEE}
+  organization={IEEE},
+  html={http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=7184920},
+  bibtex_show={true}
+}
+
+@inproceedings{jie2014multilingual,
+  abbr={COLING},
+  title={Multilingual Semantic Parsing: Parsing Multiple Languages into Semantic Representations},
+  author={Jie, Zhanming and Lu, Wei},
+  booktitle={Proceedings of COLING},
+  pages={1291--1301},
+  year={2014},
+  html={http://www.aclweb.org/anthology/C14-1122},
+  bibtex_show={true}
+}
+
+@article{guo2018matrix,
+  abbr={PRE},
+  title={Matrix Product Operators for Sequence to Sequence Learning},
+  author={Guo, Chu and Jie, Zhanming and Lu, Wei and Poletti, Dario},
+  journal={Physical Review E},
+  year={2018},
+  arxiv={1803.10908},
+  bibtex_show={true}
+}
+
+@article{cheung2015connection,
+  abbr={TMM},
+  title={Connection Discovery Using Big Data of User-Shared Images in Social Media},
+  author={Cheung, Ming and She, James and Jie, Zhanming},
+  journal={IEEE Transactions on Multimedia 17.9 (2015): 1417-1428},
+  year={2015},
+  html={http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=7165677},
+  bibtex_show={true}
 }

--- a/_config.yml
+++ b/_config.yml
@@ -205,11 +205,14 @@ jekyll-archives:
 
 scholar:
 
-  last_name: Einstein
-  first_name: [Albert, A.]
+  last_name: Jie
+  first_name: [Zhanming, Allan, Z.]
 
   style: apa
   locale: en
+
+  sort_by: year
+  order: descending
 
   source: /_bibliography/
   bibliography: papers.bib

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,7 +2,7 @@
 layout: about
 title: About
 permalink: /
-subtitle: 
+subtitle: <strong>NLP Scientist</strong> &middot; ByteDance AI Lab, Singapore &nbsp;|&nbsp; PhD, SUTD StatNLP Group
 
 nav: false
 
@@ -15,7 +15,7 @@ profile:
     <p>Your City, State 12345</p> -->
 
 news: true  # includes a list of news items
-selected_papers: false # includes a list of papers marked as "selected={true}"
+selected_papers: true # includes a list of papers marked as "selected={true}"
 social: true  # includes social icons at the bottom of the page
 ---
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -2,39 +2,17 @@
 layout: page
 permalink: /publications/
 title: Publications
+description: A full list of my publications. See also my <a href="https://scholar.google.com/citations?user=u68TA6oAAAAJ">Google Scholar</a> profile.
 nav: true
 ---
 <!-- _pages/publications.md -->
 
+<div class="publications">
 
+<h2 class="bib-section-title">Conference Papers</h2>
+{% bibliography -f papers -q @inproceedings %}
 
-### Conference Papers
-1. **Zhanming Jie**, Jierui Li, and Wei Lu. "[_Learning to Reason Deductively: Math Word Problem Solving as Complex Relation Extraction._](https://arxiv.org/pdf/2203.10316v1.pdf)" In Proceedings of ACL, 2022. [\[code\]](https://github.com/allanj/Deductive-MWP)
+<h2 class="bib-section-title">Journal Papers</h2>
+{% bibliography -f papers -q @article %}
 
-1. Yuxiang Zhou, Lejian Liao, Yang Gao, **Zhanming Jie** and Wei Lu. "[_To be Closer: Learning toLink up Aspect with Opinions._](https://aclanthology.org/2021.emnlp-main.317.pdf)" In Proceedings of EMNLP, 2021. [\[code\]](https://github.com/zyxnlp/aclt)
-
-2. Lu Xu, **Zhanming Jie**, Wei Lu and Lidong Bing. "[_Better Feature Integration for Named Entity Recognition_](https://www.aclweb.org/anthology/2021.naacl-main.271.pdf)" In Proceedings of NAACL, 2021. [\[code\]](https://github.com/xuuuluuu/SynLSTM-for-NER)
-
-3. Liying Cheng, Dekun Wu, Lidong Bing, Yan Zhang, **Zhanming Jie**, Wei Lu, Luo Si. "[_ENT-DESC: Entity Description Generation by Exploring Knowledge Graph_](https://www.aclweb.org/anthology/2020.emnlp-main.90/)" In Proceedings of EMNLP, 2020. [\[code\]](https://github.com/LiyingCheng95/EntityDescriptionGeneration) [\[Slides\]](https://docs.google.com/presentation/d/1xuZ48Yl-wIHdrZME15Iimcw3eSQTF9_TiaIS7Mu6SoU/edit?usp=sharing)
-
-4. Xuefeng Yang, Benhong Wu, **Zhanming Jie**, Yunfeng Liu. "[_Overview of the NLPCC 2020 Shared Task: AutoIE_](https://link.springer.com/chapter/10.1007/978-3-030-60457-8_46)" In Proceedings of NLPCC, 2020
-
-5. **Zhanming Jie** and Wei Lu. "[_Dependency-guided LSTM-CRF for Named Entity Recognition_](https://arxiv.org/abs/1909.10148) " In Proceedings of EMNLP, 2019. [\[code\]](https://github.com/allanj/ner_with_dependency) [\[Slides\]](https://docs.google.com/presentation/d/1tk0EcChsI-DIt0LvFVcubKvpCi3Ptg6OrnRx5U-CsO0/edit?usp=sharing)
-
-6. **Zhanming Jie**, Pengjun Xie, Wei Lu, Ruixue Ding and Linlin Li. "[_Better Modeling of Incomplete Annotations for Named Entity Recognition_](https://www.aclweb.org/anthology/N19-1079) " In Proceedings of NAACL, 2019. [\[code\]](https://github.com/allanj/ner_incomplete_annotation/) [\[Slides\]](http://people.sutd.edu.sg/~allanjie/wp-content/uploads/2019/07/presentation.pdf)
-
-7. **Zhanming Jie** and Wei Lu. "[_Dependency-based Hybrid Trees for Semantic Parsing_](https://arxiv.org/abs/1809.00107) " In Proceedings of EMNLP, 2018. [\[code\]](https://github.com/allanj/dep-hybrid-tree) [\[Slides\]](http://people.sutd.edu.sg/~allanjie/wp-content/uploads/2016/04/dht_seminar_conf.pdf)
-
-8. **Zhanming Jie**, Aldrian Obaja Muis and Wei Lu. "[_Efficient Dependency-Guided Named Entity Recognition_](http://people.sutd.edu.sg/~allanjie/wp-content/uploads/2017/02/jie.pdf) " In Proceedings of AAAI, 2017. [\[code\]](https://gitlab.com/allanjie/dependeny-guided-ner) [\[Slides\]](http://www.statnlp.org/wp-content/uploads/2017/02/slides.pdf)
-
-9. **Zhanming Jie** Ming Cheung, and James She. "[_A Cloud-Assisted Framework for Bag-of-Features Tagging in Social Networks_](http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=7340054) " In Proceedings of IEEE Fourth Symposium on Network Cloud Computing and Applications, 2015
-
-10. Alvin Junus, Ming Cheung, James She, and **Zhanming Jie**. "[_Community-Aware Prediction of Virality Timing Using Big Data of Social Cascades_](http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=7184920) " In Proceedings of  IEEE First International Conference on Big Data Computing Service and Applications, 2015
-
-11. **Zhanming Jie** and Wei Lu. "[_Multilingual Semantic Parsing: Parsing Multiple Languages into Semantic Representations_](http://www.aclweb.org/anthology/C14-1122) " In Proceedings of COLING, 2014. 
-
-### Journal Papers
-1. Chu Guo, **Zhanming Jie**, Wei Lu and Dario Poletti. "[_Matrix Product Operators for Sequence to Sequence Learning._](https://arxiv.org/abs/1803.10908)" In Physical Review E. 2018
-
-2. Ming Cheung, James She, and **Zhanming Jie**. "[_Connection Discovery Using Big Data of User-Shared Images in Social Media._](http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=7165677) " In IEEE Transactions on Multimedia 17.9 (2015): 1417-1428.
-
+</div>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -9,6 +9,40 @@ p, h1, h2, h3, h4, h5, h6, em, div, li, span, strong {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
+// Readable body copy: slightly larger text and roomier line-height.
+body {
+  font-size: 17px;
+  line-height: 1.6;
+}
+
+.post .post-content,
+article {
+  p, li {
+    line-height: 1.6;
+  }
+}
+
+// Role / affiliation subtitle under the name on the about page.
+.post-header .desc {
+  color: var(--global-text-color-light);
+  font-size: 1.1rem;
+  margin-top: 0.4rem;
+  strong {
+    color: var(--global-theme-color);
+  }
+}
+
+// Section headings on the publications page (Conference / Journal).
+.publications h2.bib-section-title {
+  color: var(--global-theme-color);
+  font-size: 1.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--global-divider-color);
+  padding-bottom: 0.4rem;
+  margin-top: 2.5rem;
+  margin-bottom: 1.5rem;
+}
+
 hr {
   border-top: 1px solid var(--global-divider-color);
 }
@@ -241,8 +275,9 @@ blockquote {
 .social {
   text-align: center;
   .contact-icons {
-    font-size: 4rem;
+    font-size: 2.6rem;
     a {
+      margin: 0 0.35rem;
       i::before {
         color: var(--global-text-color);
         transition-property: all 0.2s ease-in-out;

--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -7,8 +7,8 @@
   --global-code-bg-color: #{$code-bg-color-light};
   --global-text-color: #{$black-color};
   --global-text-color-light: #{$grey-color};
-  --global-theme-color: #{$blue-color};
-  --global-hover-color: #{$blue-color};
+  --global-theme-color: #{$teal-color};
+  --global-hover-color: #{$teal-color};
   --global-footer-bg-color: #{$grey-color-dark};
   --global-footer-text-color: #{$grey-color-light};
   --global-footer-link-color: #{$white-color};
@@ -31,8 +31,8 @@ html[data-theme='dark'] {
   --global-code-bg-color: #{$code-bg-color-dark};
   --global-text-color: #{$grey-color-light};
   --global-text-color-light: #{$grey-color-light};
-  --global-theme-color: #{$cyan-color};
-  --global-hover-color: #{$cyan-color};
+  --global-theme-color: #{$teal-color-light};
+  --global-hover-color: #{$teal-color-light};
   --global-footer-bg-color: #{$grey-color-light};
   --global-footer-text-color: #{$grey-color-dark};
   --global-footer-link-color: #{$black-color};

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -12,6 +12,8 @@ $blue-color:          #0076df !default;
 $blue-color-dark:     #00369f !default;
 $cyan-color:          #2698BA !default;
 $light-cyan-color:    lighten($cyan-color, 25%);
+$teal-color:          #0f766e !default;
+$teal-color-light:    lighten($teal-color, 18%);
 $green-color:         #00ab37 !default;
 $green-color-lime:    #B7D12A !default;
 $green-color-dark:    #009f06 !default;


### PR DESCRIPTION
## Summary
Implements the high-impact improvements from the site review: a BibTeX-driven Publications page, a filled-in homepage, a distinctive theme accent, and a few typography/social polish items. All existing publication content and links are preserved verbatim.

## Publications page
- Moved **all 14 entries** (12 conference + 2 journal) into `_bibliography/papers.bib`, preserving every title, author list, venue, and PDF/arXiv/code/slides/HTML link verbatim.
- Replaced the hand-typed numbered list in `_pages/publications.md` with al-folio's `{% bibliography %}` tag, split into **Conference Papers** / **Journal Papers**, sorted newest-first.
- Set `scholar.last_name: Jie` (+ `first_name`) so **Jie / Zhanming Jie** is emphasized in author lists.
- Surfaced **PDF / arXiv / Code / Slides / HTML / Bib** buttons (`bibtex_show`).

## Homepage
- Enabled **Selected Publications** (`selected_papers: true`) and tagged 4 representative papers `selected={true}`.
- Added a styled **role/affiliation subtitle** under the name.
- News section was already enabled and populated — left as-is.

## Theme & typography
- Distinctive **deep-teal accent** (`#0f766e`) via `$theme-color`, with a lighter teal for dark mode, replacing the generic blue.
- Body type bumped to **17px / line-height 1.6**; max-width unchanged (800px).
- Right-sized the bottom **social icons** (4rem → 2.6rem) with spacing.

## Notes
- Percent-encoded the `~` in the three legacy `people.sutd.edu.sg/~allanjie/...` URLs (`%7E`) — the jekyll-scholar `latex` filter was converting the `~` into a non-breaking space and breaking the build. Functionally identical URL.
- Fixed an obvious typo in one title: *"Learning toLink up"* → *"Learning to Link up"*.
- Kept the **Twitter** icon/handle (`humbnlp`): FontAwesome 5.15.4 has no X glyph, so swapping would require a FA upgrade. Did **not** add LinkedIn / ORCID / Hugging Face since those handles weren't known — easy to add to `_config.yml` later.
- Verified with a clean local `jekyll build` + serve (homepage screenshot looks right; publications render with bold author + buttons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)